### PR TITLE
Fix time conversion that would convert 1sXXms to 1.XX0ms instead of 1.0XXms

### DIFF
--- a/times.py
+++ b/times.py
@@ -19,6 +19,7 @@ DisplayedLinesStripToTime["fennec"] = re.compile(".*ActivityManager: Fully drawn
 DisplayedLinesStripFromTime = re.compile(" .*$")
 DisplayedLinesStripMs = re.compile("([0-9]+)ms")
 DisplayedLinesSubSeconds = re.compile("s")
+DisplayedLineSubSecondsAlternative = re.compile("s.")
 RunlogPathStripTagExtension = re.compile("-.*.log$")
 
 
@@ -98,9 +99,12 @@ class Runtime:
     str_result = re.sub(DisplayedLinesStripToTime[product], "", displayed_line)
     str_result = re.sub(DisplayedLinesStripFromTime, "", str_result)
     str_result = re.sub(DisplayedLinesStripMs, ".\\1", str_result)
-    str_result = re.sub(DisplayedLinesSubSeconds, "", str_result)
+    if len(str_result.strip()) is 5:
+      str_result =  re.sub(DisplayedLineSubSecondsAlternative, ".0", str_result)
+    else:
+      str_result = re.sub(DisplayedLinesSubSeconds, "", str_result)
     try:
-      result = float(str_result) 
+      result = float(str_result)
     except ValueError as ve:
       raise ValueError(ve) 
 


### PR DESCRIPTION
Fixes issue  [#65](https://github.com/mozilla-mobile/perf-frontend-issues/issues/65) by inserting a 0 after the decimal place if the readings received from Android is 1sXXms. The Android `ReportFullyDrawn` seems to report numbers in a more human friendly way. I.e: it will omit to put a 0 in the tenths decimal place.