### PR TITLE
Fix time parsing for applink and add some simple unit tests

### DIFF
--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -1,0 +1,100 @@
+import os
+import unittest
+import sys
+
+sys.path[:0] = [os.path.abspath(os.path.join(__file__, '..', '..'))]
+import times
+
+
+class TestTimes(unittest.TestCase):
+    nightly_lines = [
+        '01-02 03:04:05.000  1784  7719 I WindowManager: Hello there',
+        ('01-02 03:04:06.000  1784  7719 I ActivityManager: Fully drawn '
+         'org.mozilla.fenix.nightly/org.mozilla.fenix.HomeActivity: +941ms'),
+        '01-02 03:04:07.000  1784  7719 I ActivityManager: This is a message',
+        ('01-02 03:04:08.000  1784  7719 I ActivityManager: Fully drawn '
+         'org.mozilla.fenix.nightly/org.mozilla.fenix.HomeActivity: +1s41ms '
+         '(total 1s529ms)'),
+    ]
+
+    performance_lines = [
+        '01-02 03:04:05.000  1784  7719 I WindowManager: Hello there',
+        ('01-02 03:04:06.000  1784  7719 I ActivityManager: Fully drawn '
+         'org.mozilla.fenix.performancetest/org.mozilla.fenix.HomeActivity: '
+         '+941ms'),
+        '01-02 03:04:07.000  1784  7719 I ActivityManager: This is a message',
+        ('01-02 03:04:08.000  1784  7719 I ActivityManager: Fully drawn '
+         'org.mozilla.fenix.performancetest/org.mozilla.fenix.HomeActivity: '
+         '+1s41ms (total 1s529ms)'),
+    ]
+
+    fennec_lines = [
+        '01-02 03:04:05.000  1784  7719 I WindowManager: Hello there',
+        ('01-02 03:04:06.000  1784  7719 I ActivityManager: Fully drawn '
+         'org.mozilla.firefox/org.mozilla.gecko.BrowserApp: +941ms'),
+        '01-02 03:04:07.000  1784  7719 I ActivityManager: This is a message',
+        ('01-02 03:04:08.000  1784  7719 I ActivityManager: Fully drawn '
+         'org.mozilla.firefox/org.mozilla.gecko.BrowserApp: +1s41ms '
+         '(total 1s529ms)'),
+    ]
+
+    def test_match_fenix_nightly(self):
+        result = times.Runtime.find_displayed_lines('fenix-nightly',
+                                                    self.nightly_lines)
+        self.assertEqual(result, [
+            self.nightly_lines[1], self.nightly_lines[3]
+        ])
+
+    def test_match_fenix_performance(self):
+        result = times.Runtime.find_displayed_lines('fenix-performance',
+                                                    self.performance_lines)
+        self.assertEqual(result, [
+            self.performance_lines[1], self.performance_lines[3]
+        ])
+
+    def test_match_fennec(self):
+        result = times.Runtime.find_displayed_lines('fennec',
+                                                    self.fennec_lines)
+        self.assertEqual(result, [
+            self.fennec_lines[1], self.fennec_lines[3]
+        ])
+
+    def test_convert_fenix_nightly(self):
+        self.assertEqual(times.Runtime.convert_displayed_line_to_time(
+            self.nightly_lines[1], 'fenix-nightly'
+        ), 0.941)
+        self.assertEqual(times.Runtime.convert_displayed_line_to_time(
+            self.nightly_lines[3], 'fenix-nightly'
+        ), 1.041)
+        with self.assertRaises(ValueError):
+            times.Runtime.convert_displayed_line_to_time(
+                self.nightly_lines[0], 'fenix-nightly'
+            )
+
+    def test_convert_fenix_performance(self):
+        self.assertEqual(times.Runtime.convert_displayed_line_to_time(
+            self.performance_lines[1], 'fenix-performance'
+        ), 0.941)
+        self.assertEqual(times.Runtime.convert_displayed_line_to_time(
+            self.performance_lines[3], 'fenix-performance'
+        ), 1.041)
+        with self.assertRaises(ValueError):
+            times.Runtime.convert_displayed_line_to_time(
+                self.performance_lines[0], 'fenix-performance'
+            )
+
+    def test_convert_fennec(self):
+        self.assertEqual(times.Runtime.convert_displayed_line_to_time(
+            self.fennec_lines[1], 'fennec'
+        ), 0.941)
+        self.assertEqual(times.Runtime.convert_displayed_line_to_time(
+            self.fennec_lines[3], 'fennec'
+        ), 1.041)
+        with self.assertRaises(ValueError):
+            times.Runtime.convert_displayed_line_to_time(
+                self.fennec_lines[0], 'fennec'
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/times.py
+++ b/times.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Parses log files, calculates average time for the included test runs, and
-saves the result to disk.
+# saves the result to disk.
 
 import glob
 from enum import Enum

--- a/times.py
+++ b/times.py
@@ -26,7 +26,6 @@ DisplayedLinesStripToTime["fennec"] = re.compile(".*ActivityManager: Fully drawn
 DisplayedLinesTime = re.compile(r"""
   (?:(\d+)s)?   # Find seconds if present and store in the first group
   (?:(\d+)ms)?  # Find milliseconds if present and store in the second group
-  $
 """, re.VERBOSE)
 RunlogPathStripTagExtension = re.compile("-.*.log$")
 
@@ -105,6 +104,8 @@ class Runtime:
     str_result: str = ""
     str_result = re.sub(DisplayedLinesStripToTime[product], "", displayed_line)
     m = re.search(DisplayedLinesTime, str_result)
+    if m.group(1) is None and m.group(2) is None:
+      raise ValueError('unable to convert line to time')
     return float(m.group(1) or 0) + float(m.group(2) or 0) / 1000
 
 def csv_format_calculations(calculations: Mapping[str, str]) -> str:


### PR DESCRIPTION
The first two commits in this series are the only ones really necessary for fixing `times.py`, but to help improve things in the longer term, I've also started some simple unit tests as well as fixing most of the `flake8` linter errors (I'm ignoring indent-width and line-length errors for now just because it would mess with commit history, though I'm happy to fix those as well so we can comply with PEP8).

Later, we should probably support running the tests via `tox` or something, but for now, you can run it with `python tests/test_times.py`.