### PR TITLE
No issue: fix HANOOB dates for 02.24 & after

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -92,7 +92,7 @@ function validate_product {
   product=$1
 
   case ${product} in
-    fennec|fenix-nightly|fenix-performance)
+    fennec|fenix-nightly|fenix-performance|fennec-nightly)
       ;;
     *)
       return 1

--- a/manual_do_times.sh
+++ b/manual_do_times.sh
@@ -16,7 +16,7 @@ cd ${iamhere}
 log_dir=/opt/fnprms/manual/
 
 if [ $# -ne 1 ]; then
-  echo "$0 <fennec|fenix-nightly|fenix-performance>";
+  echo "$0 <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>";
   exit
 fi
 

--- a/times.py
+++ b/times.py
@@ -345,6 +345,13 @@ if __name__ == "__main__":
   output_dir = arguments.output_dir
   product = arguments.product
 
+  # This variant is added on the TOR machine to make common_products.sh work
+  # with a separate armv7 URL. However, this script won't work because it hardcodes
+  # support for each variant. To simplify implementation, we just transform the variant
+  # into the appropriate supported one.
+  if product == 'fennec-nightly-g5':
+    product = 'fennec-nightly'
+
   if (not validate_product(product)):
     print("Cannot run with invalid product: " + product + ".")
   else:


### PR DESCRIPTION
Root cause analysis, suspected: `do_times` was changed to use the product `fennec-nightly-g5`. times.py did not support this input and errored out, resulting in results "NA".

I tested this works correctly by downloading a HANOOB log from today and running `manual_do_times.sh` on it.