### PR TITLE
For #69: correct errors in our G5 numbers

### DIFF
--- a/common_products.sh
+++ b/common_products.sh
@@ -13,11 +13,17 @@ APPLINK_URL="https://example.com"
 
 # Define "parameters" needed to execute all the tests. These names should
 # be self explanatory. See README.md for customization information.
+#
+# fenix-nightly and fennec-nightly launch to different activities when you
+# hit the homescreen icon so the discrepancy is intentional.
+#
+# When they print logs, they both display "Fully drawn...HomeActivity" though
+# because this is ultimately the final activity displayed.
 fenix_homeactivity_start_command='am start-activity org.mozilla.fenix.nightly/org.mozilla.fenix.HomeActivity'
 fenix_applink_start_command="am start-activity -t 'text/html' -d "$APPLINK_URL" -a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.IntentReceiverActivity"
 fenix_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
 
-fennec_homeactivity_start_command='am start-activity org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity'
+fennec_homeactivity_start_command='am start-activity org.mozilla.fennec_aurora/.App'
 fennec_applink_start_command="am start-activity -t 'text/html' -d "$APPLINK_URL" -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity"
 fennec_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/arm64-v8a/geckoNightly/target.apk"
 

--- a/common_products.sh
+++ b/common_products.sh
@@ -20,11 +20,11 @@ APPLINK_URL="https://example.com"
 # When they print logs, they both display "Fully drawn...HomeActivity" though
 # because this is ultimately the final activity displayed.
 fenix_homeactivity_start_command='am start-activity org.mozilla.fenix.nightly/org.mozilla.fenix.HomeActivity'
-fenix_applink_start_command="am start-activity -t 'text/html' -d "$APPLINK_URL" -a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.IntentReceiverActivity"
+fenix_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.IntentReceiverActivity"
 fenix_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
 
 fennec_homeactivity_start_command='am start-activity org.mozilla.fennec_aurora/.App'
-fennec_applink_start_command="am start-activity -t 'text/html' -d "$APPLINK_URL" -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity"
+fennec_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity"
 fennec_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/arm64-v8a/geckoNightly/target.apk"
 
 fennec_url_template_g5="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"

--- a/common_products.sh
+++ b/common_products.sh
@@ -27,7 +27,7 @@ fennec_homeactivity_start_command='am start-activity org.mozilla.fennec_aurora/.
 fennec_applink_start_command="am start-activity -t 'text/html' -d "$APPLINK_URL" -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity"
 fennec_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/arm64-v8a/geckoNightly/target.apk"
 
-fennec_url_template_g5="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.2020.02.24.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
+fennec_url_template_g5="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
 
 export fpm_product=$PRODUCTID
 

--- a/common_products.sh
+++ b/common_products.sh
@@ -9,14 +9,16 @@
 # product strings: fennec, fennec-nightly, fenix-nightly, fenix-performance
 PRODUCTID=$1
 
+APPLINK_URL="https://example.com"
+
 # Define "parameters" needed to execute all the tests. These names should
 # be self explanatory. See README.md for customization information.
 fenix_homeactivity_start_command='am start-activity org.mozilla.fenix.nightly/org.mozilla.fenix.HomeActivity'
-fenix_applink_start_command='am start-activity -t "text/html" -d "about:blank" -a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.IntentReceiverActivity'
+fenix_applink_start_command="am start-activity -t 'text/html' -d "$APPLINK_URL" -a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.IntentReceiverActivity"
 fenix_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
 
 fennec_homeactivity_start_command='am start-activity org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity'
-fennec_applink_start_command='am start-activity -t "text/html" -d "https://example.com" -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity '
+fennec_applink_start_command="am start-activity -t 'text/html' -d "$APPLINK_URL" -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity"
 fennec_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/arm64-v8a/geckoNightly/target.apk"
 
 fennec_url_template_g5="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.2020.02.24.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"


### PR DESCRIPTION
This will correct behavior for the automated tests (`test`, `do_times`). This will not fix behavior for `manual_*` because they use duplicated code.

I had to comment out and change a bunch of lines locally to see if this worked and I didn't get through the entire flow (I just made sure it starts the app correctly) so it's possible I got it wrong.