### PR TITLE
For #69: reduce duplication in code supporting manual testing, improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ To use the system manually, run:
 ## Installation
 
 ### Pre-run Customization:
-1. `common.sh`:
+`common_devices.sh`:
 - `ADB`: Change to the location of `adb` on the system.
 
-For tests run under automation:
-1. `test.sh`:
-- `log_dir`: Change to the location to store test output logs.
-1. `do_times.sh`:
-- `log_dir`: Change to the location where test output logs can be found. This value should match `log_dir` specified in `test.sh`.
+`common.sh`:
+- ``fpm_log_dir`: Change the location to store test output logs (default is only writable on root)
 
-For tests run manaully:
-1. `manual_test.sh`:
-- `log_dir`: Change to the location to store test output logs.
-1. `manual_dotimes.sh`:
-- `log_dir`: Change to the location where test output logs can be found. This value should match `log_dir` specified in `manual_test.sh`.
+`manual_test.sh`:
+- `run_test...`: lower integer run count if you don't want the test to take as long (though this may impact accuracy)
+
+### Running manually
+A typical invocation to run start to homescreen tests on Fenix's fennecNightly variant:
+```
+./manual_test.sh <fennec-nightly-apk> hanoob fennec-nightly && ./manual_do_times.sh fennec-nightly && cat <logs>/hanoob-results.csv
+```
 
 ## LICENSE
 

--- a/common.sh
+++ b/common.sh
@@ -32,7 +32,6 @@ echo "with iterations:" ${fpm_iterations}
 echo "with prefix directory:" ${fpm_prefix_dir}
 echo "with log directory:" ${fpm_log_dir}
 
-APP_LINK_URL="https://example.com"
 
 # sweep_files_older_than
 #
@@ -56,29 +55,6 @@ function sweep_files_older_than {
   done
 }
 
-# validate_use_case
-#
-# Params:
-# 1: use_case
-#
-# Determine if _use_case_ is valid.
-#
-# Return Value:
-# 0 if _use_case_ is valid; 1 otherwise
-function validate_use_case {
-  use_case=$1
-
-  case ${use_case} in
-    ha|al|hanoob)
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-
-  return 0
-}
-
 # validate_product
 #
 # Params:
@@ -96,114 +72,6 @@ function validate_product {
       ;;
     *)
       return 1
-      ;;
-  esac
-
-  return 0
-}
-
-# package_name_for_product
-#
-# Params:
-# 1: product
-#
-# Get the package name corresponding to the product
-#
-# Output:
-# A string representing the package name of _product_
-# Return Value:
-# 1 if _product_ is not a valid product; 0 otherwise.
-function package_name_for_product {
-  product=$1
-  shift
-
-  validate_product ${product}
-  if [ $? -ne 0 ]; then
-    return 1
-  fi
-    case ${product} in
-    fenix-nightly)
-      echo "org.mozilla.fennec_aurora"
-      ;;
-    fenix-performance)
-      echo "org.mozilla.fenix.performancetest"
-      ;;
-    fennec)
-      echo "org.mozilla.firefox"
-      ;;
-  esac
-  return 0
-}
-
-# intent_for_configuration
-#
-# Params:
-# 1: use_case
-# 2: product
-#
-# For the _use_case_ of _product_, get an intent that can be
-# used to launch the app in that way.
-#
-# Output:
-# The intent, usable with adb start, that will launch _product_
-# for _use_case_.
-# Return Value:
-# 1 if either _product_ or _use_case_ are invalid; 0 otherwise.
-function intent_for_configuration {
-  use_case=$1
-  shift
-  product=$1
-  shift
-
-  validate_use_case ${use_case}
-  if [ $? -ne 0 ]; then
-    return 1
-  fi
-
-  validate_product ${product}
-  if [ $? -ne 0 ]; then
-    return 1
-  fi
-
-  case ${use_case} in
-    al)
-      case ${product} in
-	fenix-nightly)
-	  echo "-d $APP_LINK_URL -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity"
-	  ;;
-	fenix-performance)
-	  echo '-d "about:blank" -a android.intent.action.VIEW org.mozilla.fenix.performancetest/org.mozilla.fenix.IntentReceiverActivity'
-	  ;;
-	fennec)
-	  echo "-t 'text/html' -d $APP_LINK_URL -a android.intent.action.VIEW org.mozilla.firefox/org.mozilla.gecko.LauncherActivity"
-	  ;;
-      esac
-      ;;
-    ha)
-      case ${product} in
-	fenix-nightly)
-	  echo "-a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.HomeActivity"
-	  ;;
-	fenix-performance)
-	  echo "-a android.intent.action.VIEW org.mozilla.fenix.performancetest/org.mozilla.fenix.HomeActivity"
-	  ;;
-	fennec)
-	  echo "-a android.intent.action.VIEW org.mozilla.firefox/org.mozilla.gecko.BrowserApp"
-	  ;;
-      esac
-      ;;
-    hanoob)
-      case ${product} in
-	fenix-nightly)
-	  return 1
-	  ;;
-	fenix-performance)
-	  return 1
-	  ;;
-	fennec)
-	  return 1
-	  ;;
-      esac
       ;;
   esac
 

--- a/common.sh
+++ b/common.sh
@@ -55,29 +55,6 @@ function sweep_files_older_than {
   done
 }
 
-# validate_product
-#
-# Params:
-# 1: product
-#
-# Determine whether _product_ is valid
-#
-# Return Value:
-# 0 if _product_ is a valid product; 1 otherwise.
-function validate_product {
-  product=$1
-
-  case ${product} in
-    fennec|fenix-nightly|fenix-performance|fennec-nightly)
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-
-  return 0
-}
-
 # download_apk
 #
 # Params:

--- a/common_products.sh
+++ b/common_products.sh
@@ -81,3 +81,11 @@ fi
 # Report results
 echo  "product is: $PRODUCTID"
 echo  "package is: ${apk_package}"
+
+# $1 = usage str
+function validate_product {
+    if [ -z "$apk_package" ]; then
+        echo $1
+        exit 1
+    fi
+}

--- a/common_products.sh
+++ b/common_products.sh
@@ -23,9 +23,17 @@ fenix_homeactivity_start_command='am start-activity org.mozilla.fenix.nightly/or
 fenix_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.IntentReceiverActivity"
 fenix_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
 
+fenix_perf_homeactivity_start_command='am start-activity org.mozilla.fenix.performancetest/org.mozilla.fenix.HomeActivity'
+fenix_perf_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.fenix.performancetest/org.mozilla.fenix.IntentReceiverActivity"
+#fenix_perf_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
+
 fennec_homeactivity_start_command='am start-activity org.mozilla.fennec_aurora/.App'
 fennec_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.fennec_aurora/org.mozilla.fenix.IntentReceiverActivity"
 fennec_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/arm64-v8a/geckoNightly/target.apk"
+
+fennec_68_homeactivity_start_command='am start-activity org.mozilla.firefox/.App'
+fennec_68_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.firefox/org.mozilla.gecko.LauncherActivity"
+#fennec_68_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/arm64-v8a/geckoNightly/target.apk"
 
 fennec_url_template_g5="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.mobile.fenix.v2.fennec-nightly.DATE.latest/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
 
@@ -50,6 +58,24 @@ if [ "$PRODUCTID" = "fennec-nightly-g5" ]; then
     export apk_url_template=$fennec_url_template_g5
     export applink_start_command=$fennec_applink_start_command
     export homeactivity_start_command=$fennec_homeactivity_start_command
+fi
+
+if [ "$PRODUCTID" = "fenix-performance" ]; then
+    echo "$PRODUCTID: only manual_* tests supported. Please add url_template to use test*."
+
+    export apk_package=org.mozilla.fenix.performancetest
+    #export apk_url_template=
+    export applink_start_command=$fenix_perf_applink_start_command
+    export homeactivity_start_command=$fenix_perf_homeactivity_start_command
+fi
+
+if [ "$PRODUCTID" = "fennec" ]; then
+    echo "$PRODUCTID: only manual_* tests supported. Please add url_template to use test*."
+
+    export apk_package=org.mozilla.firefox
+    #export apk_url_template=
+    export applink_start_command=$fennec_68_applink_start_command
+    export homeactivity_start_command=$fennec_68_homeactivity_start_command
 fi
 
 # Report results

--- a/common_products.sh
+++ b/common_products.sh
@@ -84,7 +84,8 @@ echo  "package is: ${apk_package}"
 
 # $1 = usage str
 function validate_product {
-    if [ -z "$apk_package" ]; then
+    # At some point, the other configurations broke. Rather than fixing them, we error out.
+    if [ "$PRODUCTID" != 'fennec-nightly' ] | [ "$PRODUCTID" != 'fennec' ]; then
         echo $1
         exit 1
     fi

--- a/manual_do_times.sh
+++ b/manual_do_times.sh
@@ -14,11 +14,10 @@ cd ${iamhere}
 log_dir=/opt/fnprms/manual/
 USAGE="usage: <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>"
 
-# multi-device was added for FNPRMS in SF, which isn't where manual_test is expected to run.
-#DEVICEID=$1
+#DEVICEID=$1 # unused
 PRODUCTID=$1
 
-# . common_devices.sh $DEVICEID
+. common_devices.sh 1 # value doesn't matter
 . common_products.sh $PRODUCTID
 . common.sh
 

--- a/manual_do_times.sh
+++ b/manual_do_times.sh
@@ -12,6 +12,8 @@ iamhere=${iamhere/./${iwashere}}
 cd ${iamhere}
 
 log_dir=/opt/fnprms/manual/
+USAGE="usage: <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>"
+
 # multi-device was added for FNPRMS in SF, which isn't where manual_test is expected to run.
 #DEVICEID=$1
 PRODUCTID=$1
@@ -20,6 +22,7 @@ PRODUCTID=$1
 . common_products.sh $PRODUCTID
 . common.sh
 
+validate_product "$USAGE"
 
 {
   ./times.py --product $PRODUCTID --input_dir ${log_dir} --output_dir ${log_dir}

--- a/manual_do_times.sh
+++ b/manual_do_times.sh
@@ -11,7 +11,7 @@ iwashere=`pwd`
 iamhere=${iamhere/./${iwashere}}
 cd ${iamhere}
 
-USAGE="usage: <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>"
+USAGE="usage: <fennec|fennec-nightly>"
 
 #DEVICEID=$1 # unused
 PRODUCTID=$1

--- a/manual_do_times.sh
+++ b/manual_do_times.sh
@@ -11,7 +11,6 @@ iwashere=`pwd`
 iamhere=${iamhere/./${iwashere}}
 cd ${iamhere}
 
-log_dir=/opt/fnprms/manual/
 USAGE="usage: <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>"
 
 #DEVICEID=$1 # unused
@@ -24,7 +23,7 @@ PRODUCTID=$1
 validate_product "$USAGE"
 
 {
-  ./times.py --product $PRODUCTID --input_dir ${log_dir} --output_dir ${log_dir}
+  ./times.py --product $PRODUCTID --input_dir ${fpm_log_dir} --output_dir ${fpm_log_dir}
 }
 
 cd ${iwashere}

--- a/manual_do_times.sh
+++ b/manual_do_times.sh
@@ -11,26 +11,18 @@ iwashere=`pwd`
 iamhere=${iamhere/./${iwashere}}
 cd ${iamhere}
 
+log_dir=/opt/fnprms/manual/
+# multi-device was added for FNPRMS in SF, which isn't where manual_test is expected to run.
+#DEVICEID=$1
+PRODUCTID=$1
+
+# . common_devices.sh $DEVICEID
+. common_products.sh $PRODUCTID
 . common.sh
 
-log_dir=/opt/fnprms/manual/
-
-if [ $# -ne 1 ]; then
-  echo "$0 <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>";
-  exit
-fi
-
-product=$1
-shift
-
-validate_product ${product}
-if [ $? -ne 0 ]; then
-  echo "Invalid product name."
-  exit
-fi
 
 {
-  ./times.py --product ${product} --input_dir ${log_dir} --output_dir ${log_dir}
+  ./times.py --product $PRODUCTID --input_dir ${log_dir} --output_dir ${log_dir}
 }
 
 cd ${iwashere}

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -41,15 +41,14 @@ if [ \( "X${apk_file}" == "X" \) -o \( "X${command}" == "X" \) -o \( "X${apk_pac
   exit 1
 fi
 
-log_dir=/opt/fnprms/manual/
 test_date=`date +"%Y.%m.%d"`
 log_base=${test_date}
-run_log="${log_dir}/${log_base}.log"
+run_log="${fpm_log_dir}/${log_base}.log"
 
-maybe_create_dir ${log_dir}
+maybe_create_dir ${fpm_log_dir}
 
-maybe_create_file "${log_dir}/${log_base}-${use_case}.log"
+maybe_create_file "${fpm_log_dir}/${log_base}-${use_case}.log"
 
-run_test $apk_file "${log_dir}/${log_base}-${use_case}.log" "$apk_package" "$command" 25
+run_test $apk_file "${fpm_log_dir}/${log_base}-${use_case}.log" "$apk_package" "$command" 25
 
 cd ${iwashere}

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -7,7 +7,7 @@
 # Manually run _product_ under the _use_case_ use case where the application
 # is stored in _apk_.
 
-USAGE="usage: <apk file to test> <al|hanoob> <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>"
+USAGE="usage: <apk file to test> <al|hanoob> <fennec|fennec-nightly>"
 
 iamhere=${BASH_SOURCE%/*}
 iwashere=`pwd`

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -6,34 +7,37 @@
 # Manually run _product_ under the _use_case_ use case where the application
 # is stored in _apk_.
 
+USAGE="usage: <apk file to test> <al|hanoob> <fennec|fenix-nightly|fenix-performance|fennec-nightly|fennec-nightly-g5>"
+
 iamhere=${BASH_SOURCE%/*}
 iwashere=`pwd`
 iamhere=${iamhere/./${iwashere}}
 cd ${iamhere}
 
+apk_file=$1
+use_case=$2
+
+# multi-device was added for FNPRMS in SF, which isn't where manual_test is expected to run.
+#DEVICEID=$1
+PRODUCTID=$3
+
+# . common_devices.sh $DEVICEID
+. common_products.sh $PRODUCTID
 . common.sh
 
-apk_file=$1
-shift
-use_case=$1
-shift
-product=$1
+case $use_case in
+  al)
+    command=$applink_start_command
+    ;;
+  hanoob)
+    command=$homeactivity_start_command
+    ;;
+  # we're not actively using ha so I excluded that option.
+esac
 
-if [ \( "X${apk_file}" == "X" \) -o \( "X${use_case}" == "X" \) -o \( "X${product}" == "X" \) ]; then
-  echo "usage: <apk file to test> <ha|al|hanoob> <fennec|fenix-nightly|fenix-performance>"
+if [ \( "X${apk_file}" == "X" \) -o \( "X${command}" == "X" \) -o \( "X${apk_package}" == "X" \) ]; then
+  echo $USAGE
   exit 1
-fi
-
-ifc=$(intent_for_configuration ${use_case} ${product})
-if [ $? -ne 0 ]; then
-  echo "Cannot get intent for use case/product pair."
-  exit
-fi
-
-package_name=$(package_name_for_product ${product})
-if [ $? -ne 0 ]; then
-  echo "Cannot get intent for use case/product pair."
-  exit
 fi
 
 log_dir=/opt/fnprms/manual/
@@ -45,6 +49,6 @@ maybe_create_dir ${log_dir}
 
 maybe_create_file "${log_dir}/${log_base}-${use_case}.log"
 
-run_test ${apk_file} "${log_dir}/${log_base}-${use_case}.log" "${package_name}" "am start-activity ${ifc}" 25
+run_test $apk_file "${log_dir}/${log_base}-${use_case}.log" "$apk_package" "$command" 25
 
 cd ${iwashere}

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -17,11 +17,10 @@ cd ${iamhere}
 apk_file=$1
 use_case=$2
 
-# multi-device was added for FNPRMS in SF, which isn't where manual_test is expected to run.
-#DEVICEID=$1
+#DEVICEID=$1 # unused
 PRODUCTID=$3
 
-# . common_devices.sh $DEVICEID
+. common_devices.sh 1 # arg doesn't matter.
 . common_products.sh $PRODUCTID
 . common.sh
 

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -25,6 +25,8 @@ PRODUCTID=$3
 . common_products.sh $PRODUCTID
 . common.sh
 
+validate_product "$USAGE"
+
 case $use_case in
   al)
     command=$applink_start_command

--- a/manual_test.sh
+++ b/manual_test.sh
@@ -41,6 +41,25 @@ if [ \( "X${apk_file}" == "X" \) -o \( "X${command}" == "X" \) -o \( "X${apk_pac
   exit 1
 fi
 
+echo ""
+echo "--- RUNNING MANUAL TESTS"
+echo "--- FENIX FENNEC-NIGHTLY INSTRUCTIONS:"
+echo "- Comment out apk uninstallation & installation in run_test in common.sh."
+echo "- Install APK"
+echo "- Clear data (if was already installed)"
+echo "- (necessary in hanoob only) Clear onboarding screen manually: finishonboarding isn't work" # --finishonboarding seems broken for manual tests
+echo "- Test is not designed to measure with any open tabs, collections, or additional top sites. Test may not be accurate in this state"
+echo ""
+
+echo "--- FENNEC INSTRUCTIONS:"
+echo "- Comment out apk uninstallation & installation in run_test in common.sh."
+echo "- Install APK. If using hanoob, you MUST use the custom instrumented APK. See:"
+echo "    https://drive.google.com/drive/folders/1tnBxlrftqkjuH9OwW3FoVfD3jv4Zt4hc"
+echo "- Clear data (if was already installed)"
+echo "- (necessary in hanoob only) Clear onboarding screen manually: finishonboarding isn't work" # --finishonboarding seems broken for manual tests
+echo "- (hanoob) Test is not designed to measure if user has navigated to any website. Test may not be accurate in this state"
+echo ""
+
 test_date=`date +"%Y.%m.%d"`
 log_base=${test_date}
 run_log="${fpm_log_dir}/${log_base}.log"


### PR DESCRIPTION
The duplication in app IDs, intents, etc. has led to many changes not propagating correctly: this PR unifies our use of the app IDs by using the same values in automation & manual testing. There is still duplication in times.py but it's harder to fix that.