### PR TITLE
fixed onboarding intent

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -315,7 +315,7 @@ function run_test {
 
   warmup_start_command=${start_command}
   if [ "Xtrue" == "X${finishonboarding}" ]; then
-    warmup_start_command=`echo ${start_command} | sed 's/start-activity/start-activity --ez finishonboarding true/'`
+    warmup_start_command=`echo ${start_command} | sed 's/start-activity/start-activity --ez performancetest true/'`
   fi
 
   rm -f ${log_file} > /dev/null 2>&1


### PR DESCRIPTION
Onboarding intent was deprecated since we had move to another one (`performancetest` ) to remove tracker popup