### PR TITLE
For #94: Reduce noise in test runs by sleeping for 1s after killing the app

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -203,6 +203,11 @@ function run_test {
     $ADB shell "input keyevent HOME"
     sleep 5
     $ADB shell "am force-stop ${package_name}"
+
+    # Wait a bit after killing the process so Android has time to
+    # reclaim memory and generally "settle down" to reduce
+    # statistical noise.
+    sleep 1
   done;
 
   $ADB logcat -d >> ${log_file} 2>&1


### PR DESCRIPTION
This should allow Android to "settle down" a bit and reclaim memory so that when the next run starts, we're in a more consistent state at the system level. In my local Fenix startup test script, this reduced the std dev from ~20ms to ~10ms.