### PR TITLE
For perf-frontend-issues#137: update fenix-nightly intents.

### DIFF
--- a/common_products.sh
+++ b/common_products.sh
@@ -19,8 +19,8 @@ APPLINK_URL="https://example.com"
 #
 # When they print logs, they both display "Fully drawn...HomeActivity" though
 # because this is ultimately the final activity displayed.
-fenix_homeactivity_start_command='am start-activity org.mozilla.fenix.nightly/org.mozilla.fenix.HomeActivity'
-fenix_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.fenix.nightly/org.mozilla.fenix.IntentReceiverActivity"
+fenix_homeactivity_start_command='am start-activity org.mozilla.fenix/org.mozilla.fenix.HomeActivity'
+fenix_applink_start_command="am start-activity -t 'text/html' -d '$APPLINK_URL' -a android.intent.action.VIEW org.mozilla.fenix/org.mozilla.fenix.IntentReceiverActivity"
 fenix_url_template="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mobile.v2.fenix.nightly.DATE.latest.armeabi-v7a/artifacts/public/build/armeabi-v7a/geckoNightly/target.apk"
 
 fenix_perf_homeactivity_start_command='am start-activity org.mozilla.fenix.performancetest/org.mozilla.fenix.HomeActivity'


### PR DESCRIPTION
This will allow the fenix-nightly builds on SF FNPRMS to continue
working; fennec-nightly will continue to be broken until a fix is made
upstream.